### PR TITLE
Sanitize cdata sections

### DIFF
--- a/Frends.Kungsbacka.Json.Tests/SanitizeCDataSectionsTests.cs
+++ b/Frends.Kungsbacka.Json.Tests/SanitizeCDataSectionsTests.cs
@@ -1,0 +1,115 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.Linq;
+using System.Threading;
+
+namespace Frends.Kungsbacka.Json.Tests
+{
+	[TestFixture]
+	class SanitizeCDataSectionsTests
+	{
+		[Test]
+		public void AllDataMigratedToParentAndSectionsRemoved()
+		{
+			JToken jsonWithoutCdata = JToken.Parse(_jsonWithoutCdata);
+			var result = JsonTasks.SanitizeCDataSections(
+				new SanitizeCDataSectionsInput() { JsonData = JToken.Parse(_jsonWithCdata) },
+				new SanitizeCDataSectionsOptions(),
+				CancellationToken.None)
+				.GetAwaiter()
+				.GetResult();
+
+			Assert.True(JToken.DeepEquals(result.JsonData, jsonWithoutCdata));
+		}
+
+		[Test]
+		public void NoChangesMade()
+		{
+			JToken jsonData = JToken.Parse(_jsonWithoutCdata);
+			var result = JsonTasks.SanitizeCDataSections(
+				new SanitizeCDataSectionsInput() { JsonData = jsonData },
+				new SanitizeCDataSectionsOptions(),
+				CancellationToken.None)
+				.GetAwaiter()
+				.GetResult();
+
+			Assert.True(JToken.DeepEquals(result.JsonData, jsonData));
+		}
+
+
+		readonly string _jsonWithCdata = @"
+        {
+	        ""FlowInstance"": {
+		        ""@xmlns"": ""http://www.oeplatform.org/version/2.0/schemas/flowinstance"",
+		        ""@xmlns:xsi"": ""http://www.w3.org/2001/XMLSchema-instance"",
+		        ""@xsi:schemaLocation"": ""http://www.oeplatform.org/version/2.0/schemas/flowinstance schema-3793.xsd"",
+		        ""Header"": {
+			        ""Flow"": {
+				        ""FamilyID"": ""766"",
+				        ""Version"": ""6"",
+				        ""FlowID"": ""3793"",
+				        ""Name"": {
+					        ""#cdata-section"": ""TEST Ansöka om skolskjuts till grundskola läsåret 2024/2025""
+				        }
+			        },
+			        ""FlowInstanceID"": ""190456"",
+			        ""Status"": {
+				        ""ID"": ""21762"",
+				        ""Name"": {
+					        ""#cdata-section"": ""Inkommen""
+				        }
+			        }			       
+		        },
+		        ""Values"": {
+			        ""elev"": {
+				        ""QueryID"": ""144324"",
+				        ""Name"": {
+					        ""#cdata-section"": ""Vilken elev ansöker du om skolskjuts för?""
+				        },
+				        ""CitizenIdentifier"": ""20200307TEST"",
+				        ""Firstname"": ""Testbarn"",
+				        ""Lastname"": ""5år"",
+				        ""Address"": ""Testgatan 1"",
+				        ""Zipcode"": ""123 45"",
+				        ""PostalAddress"": ""Testköping""
+			        }
+		        }
+	        }
+        }";
+
+		readonly string _jsonWithoutCdata = @"
+        {
+		  ""FlowInstance"": {
+			""@xmlns"": ""http://www.oeplatform.org/version/2.0/schemas/flowinstance"",
+			""@xmlns:xsi"": ""http://www.w3.org/2001/XMLSchema-instance"",
+			""@xsi:schemaLocation"": ""http://www.oeplatform.org/version/2.0/schemas/flowinstance schema-3793.xsd"",
+			""Header"": {
+			  ""Flow"": {
+				""FamilyID"": ""766"",
+				""Version"": ""6"",
+				""FlowID"": ""3793"",
+				""Name"": ""TEST Ansöka om skolskjuts till grundskola läsåret 2024/2025""
+			  },
+			  ""FlowInstanceID"": ""190456"",
+			  ""Status"": {
+				""ID"": ""21762"",
+				""Name"": ""Inkommen""
+			  }
+			},
+			""Values"": {
+			  ""elev"": {
+				""QueryID"": ""144324"",
+				""Name"": ""Vilken elev ansöker du om skolskjuts för?"",
+				""CitizenIdentifier"": ""20200307TEST"",
+				""Firstname"": ""Testbarn"",
+				""Lastname"": ""5år"",
+				""Address"": ""Testgatan 1"",
+				""Zipcode"": ""123 45"",
+				""PostalAddress"": ""Testköping""
+			  }
+			}
+		  }
+		}";
+	}
+}

--- a/Frends.Kungsbacka.Json.Tests/SanitizeCDataSectionsTests.cs
+++ b/Frends.Kungsbacka.Json.Tests/SanitizeCDataSectionsTests.cs
@@ -1,6 +1,8 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using Frends.Kungsbacka.Json;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using System;
+using System.Xml.Linq;
 
 namespace Frends.Kungsbacka.Json.Tests
 {
@@ -12,7 +14,7 @@ namespace Frends.Kungsbacka.Json.Tests
         {
             // Arrange
             SanitizeCDataSectionsInput input = null;
-            var options = new SanitizeCDataSectionsOptions();
+            SanitizeCDataSectionsOptions options = new SanitizeCDataSectionsOptions();
 
             // Act
             TestDelegate act = () => JsonTasks.SanitizeCDataSections(input, options);
@@ -25,8 +27,8 @@ namespace Frends.Kungsbacka.Json.Tests
         public void SanitizeCDataSections_ShouldThrowArgumentNullException_WhenJsonDataIsNull()
         {
             // Arrange
-            var input = new SanitizeCDataSectionsInput { JsonData = null };
-            var options = new SanitizeCDataSectionsOptions();
+            SanitizeCDataSectionsInput input = new SanitizeCDataSectionsInput { JsonData = null };
+            SanitizeCDataSectionsOptions options = new SanitizeCDataSectionsOptions();
 
             // Act
             TestDelegate act = () => JsonTasks.SanitizeCDataSections(input, options);
@@ -39,133 +41,176 @@ namespace Frends.Kungsbacka.Json.Tests
         public void SanitizeCDataSections_ShouldReturnEmptyObject_WhenInputIsEmptyJsonObject()
         {
             // Arrange
-            var input = new SanitizeCDataSectionsInput { JsonData = JToken.Parse("{}") };
-            var options = new SanitizeCDataSectionsOptions();
+            SanitizeCDataSectionsInput input = new SanitizeCDataSectionsInput
+            {
+                JsonData = new JObject()
+            };
+            SanitizeCDataSectionsOptions options = new SanitizeCDataSectionsOptions();
 
             // Act
-            var result = JsonTasks.SanitizeCDataSections(input, options);
+            SanitizeCDataSectionsResult result = JsonTasks.SanitizeCDataSections(input, options);
 
             // Assert
-            Assert.AreEqual("{}", result.JsonData.ToString());
+            string expected = "{}";
+            Assert.AreEqual(expected, result.JsonData.ToString(Newtonsoft.Json.Formatting.None));
         }
 
         [Test]
         public void SanitizeCDataSections_ShouldProcessSingleCDataSection()
         {
             // Arrange
-            var input = new SanitizeCDataSectionsInput
+            SanitizeCDataSectionsInput input = new SanitizeCDataSectionsInput
             {
-                JsonData = JToken.Parse("{\"#cdata-section\":\"Some value\"}")
+                JsonData = new JObject { ["#cdata-section"] = "Some value" }
             };
-            var options = new SanitizeCDataSectionsOptions();
+            SanitizeCDataSectionsOptions options = new SanitizeCDataSectionsOptions();
 
             // Act
-            var result = JsonTasks.SanitizeCDataSections(input, options);
+            SanitizeCDataSectionsResult result = JsonTasks.SanitizeCDataSections(input, options);
 
             // Assert
-            Assert.AreEqual("\"Some value\"", result.JsonData.ToString(Newtonsoft.Json.Formatting.None));
+            string expected = "\"Some value\"";
+            Assert.AreEqual(expected, result.JsonData.ToString(Newtonsoft.Json.Formatting.None));
         }
 
         [Test]
         public void SanitizeCDataSections_ShouldProcessNestedCDataSections()
         {
             // Arrange
-            var input = new SanitizeCDataSectionsInput
+            SanitizeCDataSectionsInput input = new SanitizeCDataSectionsInput
             {
-                JsonData = JToken.Parse("{\"parent\":{\"#cdata-section\":\"Nested value\"}}")
+                JsonData = new JObject
+                {
+                    ["parent"] = new JObject
+                    {
+                        ["#cdata-section"] = "Nested value"
+                    }
+                }
             };
-            var options = new SanitizeCDataSectionsOptions();
+            SanitizeCDataSectionsOptions options = new SanitizeCDataSectionsOptions();
 
             // Act
-            var result = JsonTasks.SanitizeCDataSections(input, options);
+            SanitizeCDataSectionsResult result = JsonTasks.SanitizeCDataSections(input, options);
 
             // Assert
-            Assert.AreEqual("{\"parent\":\"Nested value\"}", result.JsonData.ToString(Newtonsoft.Json.Formatting.None));
+            string expected = "{\"parent\":\"Nested value\"}";
+            Assert.AreEqual(expected, result.JsonData.ToString(Newtonsoft.Json.Formatting.None));
         }
 
         [Test]
         public void SanitizeCDataSections_ShouldProcessArraysWithCDataSections()
         {
             // Arrange
-            var input = new SanitizeCDataSectionsInput
+            SanitizeCDataSectionsInput input = new SanitizeCDataSectionsInput
             {
-                JsonData = JToken.Parse("[ {\"#cdata-section\":\"Value1\"}, {\"#cdata-section\":\"Value2\"} ]")
+                JsonData = new JArray
+                {
+                    new JObject { ["#cdata-section"] = "Value1" },
+                    new JObject { ["#cdata-section"] = "Value2" }
+                }
             };
-            var options = new SanitizeCDataSectionsOptions();
+            SanitizeCDataSectionsOptions options = new SanitizeCDataSectionsOptions();
 
             // Act
-            var result = JsonTasks.SanitizeCDataSections(input, options);
+            SanitizeCDataSectionsResult result = JsonTasks.SanitizeCDataSections(input, options);
 
             // Assert
-            Assert.AreEqual("[\"Value1\",\"Value2\"]", result.JsonData.ToString(Newtonsoft.Json.Formatting.None));
+            string expected = "[\"Value1\",\"Value2\"]";
+            Assert.AreEqual(expected, result.JsonData.ToString(Newtonsoft.Json.Formatting.None));
         }
 
         [Test]
         public void SanitizeCDataSections_ShouldLeaveRegularPropertiesUnchanged()
         {
             // Arrange
-            var input = new SanitizeCDataSectionsInput
+            SanitizeCDataSectionsInput input = new SanitizeCDataSectionsInput
             {
-                JsonData = JToken.Parse("{\"name\":\"John\",\"#cdata-section\":\"Some value\"}")
+                JsonData = new JObject
+                {
+                    ["name"] = "John",
+                    ["#cdata-section"] = "Some value"
+                }
             };
-            var options = new SanitizeCDataSectionsOptions();
+            SanitizeCDataSectionsOptions options = new SanitizeCDataSectionsOptions();
 
             // Act
-            var result = JsonTasks.SanitizeCDataSections(input, options);
+            SanitizeCDataSectionsResult result = JsonTasks.SanitizeCDataSections(input, options);
 
             // Assert
-            Assert.AreEqual("{\"name\":\"John\",\"#cdata-section\":\"Some value\"}", result.JsonData.ToString(Newtonsoft.Json.Formatting.None));
+            string expected = "{\"name\":\"John\",\"#cdata-section\":\"Some value\"}";
+            Assert.AreEqual(expected, result.JsonData.ToString(Newtonsoft.Json.Formatting.None));
         }
 
         [Test]
         public void SanitizeCDataSections_ShouldHandleComplexNestedStructure()
         {
             // Arrange
-            var input = new SanitizeCDataSectionsInput
+            SanitizeCDataSectionsInput input = new SanitizeCDataSectionsInput
             {
-                JsonData = JToken.Parse("{\"root\":{\"child\":[{\"#cdata-section\":\"Value1\"},{\"#cdata-section\":\"Value2\"}]}}")
+                JsonData = new JObject
+                {
+                    ["root"] = new JObject
+                    {
+                        ["child"] = new JArray
+                        {
+                            new JObject { ["#cdata-section"] = "Value1" },
+                            new JObject { ["#cdata-section"] = "Value2" }
+                        }
+                    }
+                }
             };
-            var options = new SanitizeCDataSectionsOptions();
+            SanitizeCDataSectionsOptions options = new SanitizeCDataSectionsOptions();
 
             // Act
-            var result = JsonTasks.SanitizeCDataSections(input, options);
+            SanitizeCDataSectionsResult result = JsonTasks.SanitizeCDataSections(input, options);
 
             // Assert
-            Assert.AreEqual("{\"root\":{\"child\":[\"Value1\",\"Value2\"]}}", result.JsonData.ToString(Newtonsoft.Json.Formatting.None));
+            string expected = "{\"root\":{\"child\":[\"Value1\",\"Value2\"]}}";
+            Assert.AreEqual(expected, result.JsonData.ToString(Newtonsoft.Json.Formatting.None));
         }
 
         [Test]
         public void SanitizeCDataSections_ShouldHandleEmptyArray()
         {
             // Arrange
-            var input = new SanitizeCDataSectionsInput
+            SanitizeCDataSectionsInput input = new SanitizeCDataSectionsInput
             {
-                JsonData = JToken.Parse("[]")
+                JsonData = new JArray()
             };
-            var options = new SanitizeCDataSectionsOptions();
+            SanitizeCDataSectionsOptions options = new SanitizeCDataSectionsOptions();
 
             // Act
-            var result = JsonTasks.SanitizeCDataSections(input, options);
+            SanitizeCDataSectionsResult result = JsonTasks.SanitizeCDataSections(input, options);
 
             // Assert
-            Assert.AreEqual("[]", result.JsonData.ToString());
+            string expected = "[]";
+            Assert.AreEqual(expected, result.JsonData.ToString(Newtonsoft.Json.Formatting.None));
         }
 
         [Test]
         public void SanitizeCDataSections_ShouldHandleMixedContent()
         {
             // Arrange
-            var input = new SanitizeCDataSectionsInput
+            SanitizeCDataSectionsInput input = new SanitizeCDataSectionsInput
             {
-                JsonData = JToken.Parse("{\"name\":\"John\",\"data\":{\"#cdata-section\":\"Nested value\"}}")
+                JsonData = new JObject
+                {
+                    ["name"] = "John",
+                    ["data"] = new JObject
+                    {
+                        ["#cdata-section"] = "Nested value"
+                    }
+                }
             };
-            var options = new SanitizeCDataSectionsOptions();
+            SanitizeCDataSectionsOptions options = new SanitizeCDataSectionsOptions();
 
             // Act
-            var result = JsonTasks.SanitizeCDataSections(input, options);
+            SanitizeCDataSectionsResult result = JsonTasks.SanitizeCDataSections(input, options);
 
             // Assert
-            Assert.AreEqual("{\"name\":\"John\",\"data\":\"Nested value\"}", result.JsonData.ToString(Newtonsoft.Json.Formatting.None));
+            string expected = "{\"name\":\"John\",\"data\":\"Nested value\"}";
+            Assert.AreEqual(expected, result.JsonData.ToString(Newtonsoft.Json.Formatting.None));
         }
     }
 }
+

--- a/Frends.Kungsbacka.Json/FrendsTaskMetadata.json
+++ b/Frends.Kungsbacka.Json/FrendsTaskMetadata.json
@@ -29,6 +29,9 @@
 		},
 		{
 			"TaskMethod": "Frends.Kungsbacka.Json.JsonTasks.Map"
+		},
+		{
+			"TaskMethod": "Frends.Kungsbacka.Json.JsonTasks.SanitizeCDataSections"
 		}
 	]
 }

--- a/Frends.Kungsbacka.Json/SanitizeCDataSectionsDefinition.cs
+++ b/Frends.Kungsbacka.Json/SanitizeCDataSectionsDefinition.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace Frends.Kungsbacka.Json
+{
+    /// <summary>
+    /// Result of the SanitizeCDataSections operation.
+    /// </summary>
+    public class SanitizeCDataSectionsResult
+    {
+        /// <summary>
+        /// The sanitized JSON object.
+        /// </summary>
+        public JToken JsonData { get; set; } = JToken.Parse("{}");
+    }
+
+    public class SanitizeCDataSectionsOptions
+    {
+    }
+
+    public class SanitizeCDataSectionsInput
+    {
+        /// <summary>
+        /// The JSON to sanitize.
+        /// </summary>
+        public JToken JsonData { get; set; }
+    }
+}

--- a/Frends.Kungsbacka.Json/SanitizeCDataSectionsTask.cs
+++ b/Frends.Kungsbacka.Json/SanitizeCDataSectionsTask.cs
@@ -1,0 +1,76 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Frends.Kungsbacka.Json
+{
+    /// <summary>
+    /// JsonSchema Tasks
+    /// </summary>
+    public static partial class JsonTasks
+    {
+        /// <summary>
+        /// Moves data contained in #cdata-section sections to the text nodes of the containing elements and removes the #cdata-section token. 
+        /// </summary>
+        /// <param name="input">Required parameters</param>
+        /// <param name="options">Optional parameters</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>JToken sanitized of #cdata-sections with data moved to parent JToken</returns>
+        public static async Task<SanitizeCDataSectionsResult> SanitizeCDataSections([PropertyTab] SanitizeCDataSectionsInput input, [PropertyTab] SanitizeCDataSectionsOptions options, CancellationToken cancellationToken)
+        {
+            if (input == null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            if (input.JsonData == null)
+            {
+                throw new ArgumentNullException(nameof(input.JsonData));
+            }
+
+            JToken token = input.JsonData.DeepClone();
+            JToken sanitized = ProcessCData(token);
+            SanitizeCDataSectionsResult result = new SanitizeCDataSectionsResult
+            {
+                JsonData = sanitized
+            };
+
+            return result;
+        }
+
+
+        /// <summary>
+        /// Recursively processes a JToken to move data contained in #cdata-section 
+        /// sections to the text nodes of the containing elements and removes the #cdata-section token.
+        /// </summary>
+        /// <param name="token">The JToken to process.</param>
+        /// <returns>The processed JToken with #cdata-section sections moved to text nodes.</returns>
+        static JToken ProcessCData(JToken token)
+        {
+            if (token is JObject obj)
+            {
+                if (obj.Properties().Count() == 1 && obj.Properties().First().Name == "#cdata-section")
+                {
+                    return obj["#cdata-section"];
+                }
+
+                foreach (var property in obj.Properties().ToList())
+                {
+                    property.Value = ProcessCData(property.Value);
+                }
+            }
+            else if (token is JArray array)
+            {
+                for (int i = 0; i < array.Count; i++)
+                {
+                    array[i] = ProcessCData(array[i]);
+                }
+            }
+
+            return token;
+        }
+    }
+}

--- a/Frends.Kungsbacka.Json/SanitizeCDataSectionsTask.cs
+++ b/Frends.Kungsbacka.Json/SanitizeCDataSectionsTask.cs
@@ -2,8 +2,6 @@
 using System;
 using System.ComponentModel;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Frends.Kungsbacka.Json
 {
@@ -19,7 +17,7 @@ namespace Frends.Kungsbacka.Json
         /// <param name="options">Optional parameters</param>
         /// <param name="cancellationToken"></param>
         /// <returns>JToken sanitized of #cdata-sections with data moved to parent JToken</returns>
-        public static async Task<SanitizeCDataSectionsResult> SanitizeCDataSections([PropertyTab] SanitizeCDataSectionsInput input, [PropertyTab] SanitizeCDataSectionsOptions options, CancellationToken cancellationToken)
+        public static SanitizeCDataSectionsResult SanitizeCDataSections([PropertyTab] SanitizeCDataSectionsInput input, [PropertyTab] SanitizeCDataSectionsOptions options)
         {
             if (input == null)
             {


### PR DESCRIPTION
Lade till metod för att ta bort #cdata-sections från json-data. #cdata-sections är vanligt förekommande i xml-svar men är bara onödigt extra när xml:en konverterats till json. Den här tasken flyttar datan från #cdata-section-tokenen till föräldern och tar sedan bort #cdata-section.

Exempelvis:
"Value": {
    "#cdata-section": "myvalue"
}

blir:
"Value":  "myvalue"